### PR TITLE
Support external and absolute URLs in import and url plugins

### DIFF
--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -1,0 +1,3 @@
+module.exports = {
+  url: /url\(([^)]+)\)/
+};

--- a/lib/plugins/imports.js
+++ b/lib/plugins/imports.js
@@ -1,14 +1,23 @@
+var loaderUtils = require('loader-utils');
 var addImport = require('./../add-import');
 var stripQuotes = require('./../strip-quotes');
+var patterns = require('./../patterns');
 
 module.exports = function(ast, reworkInstance) {
   var keepRules = [];
 
   ast.rules.forEach(function(rule) {
-    if (rule.type === 'import')
-      addImport(reworkInstance, stripQuotes(rule.import));
-    else
-      keepRules.push(rule);
+    if (rule.type === 'import') {
+      // accept both url('someUrl') and 'someUrl'
+      var matches = patterns.url.exec(rule.import);
+      var url = stripQuotes(matches && matches[1] || rule.import);
+      // make sure it's not external url, etc.
+      // this behaviour matches the webpack's own css-loader behaviour
+      if (loaderUtils.isUrlRequest(url)) {
+        return addImport(reworkInstance, loaderUtils.urlToRequest(url));
+      }
+    }
+    keepRules.push(rule);
   });
 
   ast.rules = keepRules;

--- a/lib/plugins/urls.js
+++ b/lib/plugins/urls.js
@@ -1,4 +1,5 @@
 var urlParse = require('url').parse;
+var loaderUtils = require('loader-utils');
 
 var addImport = require('./../add-import');
 var stripQuotes = require('./../strip-quotes');
@@ -16,10 +17,17 @@ module.exports = function(ast, reworkInstance) {
         return;
 
       declaration.value = declaration.value
-        .replace(urlRe, function(_, url) {
+        .replace(urlRe, function(declarationValue, url) {
           url = stripQuotes(url);
-          addImport(reworkInstance, urlParse(url).pathname);
-          return 'url("' + mark(url) + '")';
+          // make sure it's not external url, etc. before rewriting it
+          // this behaviour matches the webpack's own css-loader behaviour
+          if (loaderUtils.isUrlRequest(url)) {
+            url = loaderUtils.urlToRequest(url);
+            addImport(reworkInstance, urlParse(url).pathname);
+            return 'url("' + mark(url) + '")';
+          } else {
+            return declarationValue;
+          }
         });
     });
   });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "rework-npm": "~1.0.0",
     "rework-custom-media": "~0.2.0",
     "rework-vars": "~3.1.1",
-    "rework-visit": "~1.0.0"
+    "rework-visit": "~1.0.0",
+    "loader-utils": "^0.2.5"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
For example, it's now possible to have @import url('http://fonts.googleapis.com/css?family=Lato:300,400,700');

In addition, convert url(image.png) => require("./image.png") the way css-loader does.

The methods for testing and converting the URLs can be found here
https://github.com/webpack/loader-utils/blob/db3c7cd123355f61846497ebeef614670c075ed9/index.js#L93-L142

See the css-loader for reference
See https://github.com/webpack/css-loader/blob/70771dc2586d90439b370c6d3b5921e48058a4fe/index.js

Not sure if this is backwards compatible with the current version of rework-webpack-loader or not.
